### PR TITLE
add: add trashed flight and restore delete flight api

### DIFF
--- a/app/Http/Controllers/FlightController.php
+++ b/app/Http/Controllers/FlightController.php
@@ -84,7 +84,7 @@ class FlightController extends Controller
     }
 
     /**
-     * Delete specific flights data
+     * Delete specific flight data
      */
     public function destroy(int $id) {
         try {
@@ -103,6 +103,51 @@ class FlightController extends Controller
             return response()->json([
                 'status' => 'error',
                 'message' => 'エラーが発生しました。' . $e->getMessage()
+            ], 500);
+        }
+    }
+
+    /**
+     * Restore specific flight data
+     */
+    public function restore(int $id) {
+        try {
+            // restore the flight by id
+            $result = $this->flightService->restoreFlight($id);
+
+            return response()->json([
+                'status' => 'success',
+                'message' => 'フライトのデータが正常に復元されました'
+            ]);
+        } catch (ModelNotFoundException $e) {
+            return response()->json([
+                'status' => 'error',
+                'message' => '削除されたフライトが見つかりませんでした。'
+            ], 404);
+        } catch (Exception $e) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'エラーが発生しました。' . $e->getMessage()
+            ], 500);
+        }
+    }
+
+    /**
+     * Get all deleted flight data
+     */
+    public function trashed() {
+        try {
+            $flights = $this->flightService->getTrashedFlights();
+
+            return response()->json([
+                'status' => 'success',
+                'data' => $flights
+            ]);
+        } catch (Exception $e) {
+            // Error handling
+            return response()->json([
+                'status' => 'error',
+                'message' => 'エラーが発生しました：' . $e->getMessage()
             ], 500);
         }
     }

--- a/app/Services/FlightService.php
+++ b/app/Services/FlightService.php
@@ -65,4 +65,35 @@ class FlightService {
 
         return $flight->delete();
     }
+
+    /**
+     *
+     * Restore deleted flight data by id
+     * 
+     *  @param array $data Validated Flight Data
+     *  @return Flight
+     *  @throws Exception
+     */
+    public function restoreFlight(int $id): bool {
+        // find deleted flight data by id
+        $flight = Flight::onlyTrashed()
+            ->findOrFail($id)
+            ->restore();
+        
+        return $flight;
+    }
+
+    /**
+     *
+     * show deleted flights data
+     * 
+     *  @param array $data Validated Flight Data
+     *  @return Flight
+     *  @throws Exception
+     */
+    public function getTrashedFlights(): Collection {
+        return Flight::onlyTrashed()
+            ->orderBy('deleted_at', 'desc')
+            ->get();
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,7 +8,15 @@ Route::get('/user', function (Request $request) {
     return $request->user();
 })->middleware('auth:sanctum');
 
-// Flight related
+/**
+ * Flight Related API Routes
+ */
+
+// Specific Route
+Route::get('flights/trashed', [FlightController::class, 'trashed']);
+Route::post('flights/{id}/restore', [FlightController::class, 'restore']);
+
+// General Route
 Route::post('flight', [FlightController::class, 'store'])->withoutMiddleware('auth:sanctum');
 Route::get('flights', [FlightController::class, 'index']);
 Route::get('flights/{id}', [FlightController::class, 'show']);


### PR DESCRIPTION
### What I did?
- restore deleted flight by id has added
- get trashed flights has added

### result
- `GET`: `api/flights/trashed`
```
{
    "status": "success",
    "data": [
        {
            "id": 3,
            "boarding_date": "2025-04-26T00:00:00.000000Z",
            "departure": "HND",
            "destination": "OKA",
            "flight_number": "NH477",
            "ticket_price": 11500,
            "fare_type": "SV75",
            "other_expenses": 1180,
            "earned_pp": 1175,
            "status": false,
            "pp_unitprice": "9.79",
            "created_at": "2025-04-23T10:47:28.000000Z",
            "updated_at": "2025-04-24T09:59:49.000000Z",
            "deleted_at": "2025-04-24T09:59:49.000000Z"
        }
    ]
}
```

- `POST`: `api/flights/{id}/restore`
```
{
    "status": "success",
    "message": "フライトのデータが正常に復元されました"
}

```